### PR TITLE
Pass task options to enb.createBuilder as is

### DIFF
--- a/tasks/enb.js
+++ b/tasks/enb.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
                 options = this.options({
                 noLog: false
             }),
-            enbBuilder = enb.createBuilder({ noLog: options.noLog}),
+            enbBuilder = enb.createBuilder(options),
             tasks = [],
             _this = this,
             async = require('async');


### PR DESCRIPTION
I want to pass `options.cdir` to enb, but `{noLog: options.noLog}` blocks it...
