### PR TITLE
Исправлено подвисание при ошибке

### DIFF
--- a/tasks/enb.js
+++ b/tasks/enb.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
         });
         async.parallel(tasks, function (err) {
             if (err)
-                return grunt.log.error(err);
+				return grunt.fail.fatal(err);
 
             _this.data.afterBuild && _this.data.afterBuild();
             done();

--- a/tasks/enb.js
+++ b/tasks/enb.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
         });
         async.parallel(tasks, function (err) {
             if (err)
-				return grunt.fail.fatal(err);
+                return grunt.fail.fatal(err);
 
             _this.data.afterBuild && _this.data.afterBuild();
             done();


### PR DESCRIPTION
Если таск падал с ошибкой, то он никогда не завершался.
Так как уровень error, не инициирует остановку цепочки тасков и done никогда не вызывается.

Повысил уровень ошибки, так как мне кажется таск должен именно падать если не удалось выполнить сборку.